### PR TITLE
Panic Serveur et vérification images

### DIFF
--- a/src/elputils/tcpio.go
+++ b/src/elputils/tcpio.go
@@ -19,6 +19,7 @@ func SendString(conn net.Conn, string string) {
 	// send the string string
 	_, err := io.WriteString(conn, fmt.Sprint(string))
 	if err != nil {
+		fmt.Println("Error - SendString")
 		panic(err)
 	}
 }
@@ -27,6 +28,7 @@ func SendString(conn net.Conn, string string) {
 func ReceiveString(conn net.Conn, delimiter byte) string {
 	message, err := bufio.NewReader(conn).ReadString(delimiter)
 	if err != nil {
+		fmt.Println("Error - ReceiveString")
 		panic(err)
 	}
 	return message
@@ -56,6 +58,8 @@ func UploadFile(conn net.Conn, srcFile string) {
 		fmt.Println(err)
 		return
 	}
+	defer file.Close()
+
 	fileInfo, err := file.Stat()
 	if err != nil {
 		fmt.Println(err)

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -50,14 +50,26 @@ func main() {
 	}
 }
 
+// function to avoid the server to crash if a panic statement is raised due to a client
+func defusePanic(connection net.Conn, connId int){
+	if r := recover(); r!= nil {
+		fmt.Println("recovered from ", r)
+		fmt.Println("Panic due to client:", connId)
+	}
+}
+
 // Handles a new connection initiated with a client
 // Client must send a filter id and a image blob
 func handleConnection(connection net.Conn, connId int) {
+	// defusePanic will be executed if there is a panic statement raised
+	defer defusePanic(connection, connId)
+
 	fmt.Printf("New connection with a client, id %d\n", connId)
 
 	// Send available filters as contatenated array
 	fmt.Println("Sending filter list to the client")
 	elputils.SendArray(connection, elputils.FilterList)
+	defer connection.Close()
 
 	// Receive filter and send back 1 or 0 wether it's valid or not
 	filter := elputils.ReceiveFilter(connection, len(elputils.FilterList))


### PR DESCRIPTION
En cas de crash du client (exemple: le client quitte en pleine transmission, avant d'envoyer les infos ...), la fonction panicDefuse du serveur permet d'éviter que le serveur crash et ferme le connexion avec le client.

Côté client : création d'une fonction InputImageVerification indépendante de InputImagePath afin de permettre son utilisation dans le client en ligne de commande.

Correction de bugs en cas d'erreur de saisie des filtres ou des chemins d'images